### PR TITLE
Fixes code blocks in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,111 +59,114 @@
 
 Installing the package via composer:
 
-	composer require lsrur/inspector
+```bash
+composer require lsrur/inspector
+```
 
+Next, add InspectorServiceProvider to the providers array in `config/app.php`:
 
-Next, add InspectorServiceProvider to the providers array in <code>config/app.php</code>:
-
-	Lsrur\Inspector\InspectorServiceProvider::class,
-
+```php
+Lsrur\Inspector\InspectorServiceProvider::class,
+```
   
 And this Facade in the same configuration file:
 
-	'Inspector' => Lsrur\Inspector\Facade\Inspector::class,
-	
+```php
+'Inspector' => Lsrur\Inspector\Facade\Inspector::class,
+```
 
 
 ## <a name="configuration"></a>Configuration
 
-In order to use Inspector as the default exceptions renderer, add the following line in the file <code>app/Exceptions/Handler.php</code> of your Laravel project:
+In order to use Inspector as the default exceptions renderer, add the following line in the file `app/Exceptions/Handler.php` of your Laravel project:
 
 ```php    
-    public function render($request, Exception $e)
-    {
-        \Inspector::renderException($e); 	// <= THIS LINE
-        return parent::render($request, $e);
-    }  
+public function render($request, Exception $e)
+{
+    \Inspector::renderException($e); 	// <= THIS LINE
+    return parent::render($request, $e);
+}  
 ```      
 
   
 ## <a name="usage"></a>Usage
 Laravel inspector can be invoked using the Facade, the provided helper functions and a Blade directive:
 
-```php	
-	//Using Facade
-	\Inspector::log(...);
-	\Inspector::info(...);
+```php
+//Using Facade
+\Inspector::log(...);
+\Inspector::info(...);
 		
-	//Using the "inspector" helper function
-	inspector()->info(...);
-	inspector()->warning($myVar);
+//Using the "inspector" helper function
+inspector()->info(...);
+inspector()->warning($myVar);
 	
-	// "li" is an alias of "inspector"
-	li()->error(...);
-	li()->group('myGroup');
+// "li" is an alias of "inspector"
+li()->error(...);
+li()->group('myGroup');
 	
-	// "inspect" function makes an "Inspector::log($v)" for each passed argument
-	inspect($var1, $var2, $var3, ...);
+// "inspect" function makes an "Inspector::log($v)" for each passed argument
+inspect($var1, $var2, $var3, ...);
 	
-	// Dump and die using Laravel Inspector magic
-	idd();
-	idd($var1, $var2);
+// Dump and die using Laravel Inspector magic
+idd();
+idd($var1, $var2);
 	
-	// Inside Blade
-	@li(cmd,param1,param2,...)
+// Inside Blade
+@li(cmd,param1,param2,...)
 	
-	// samples
-	@li('log', 'My comment', $myVar)
-	@li(log, 'My comment', $myVar) //also works with no command quotes
-	@li(group,"myGroup")
-	@li(endGroup)
-	
+// samples
+@li('log', 'My comment', $myVar)
+@li(log, 'My comment', $myVar) //also works without command quotes
+@li(group,"myGroup")
+@li(endGroup)
 ```	
 
-**Laravel inspector will only be active if the config variable <code>app.debug</code> is true.**  
+**Laravel inspector will only be active if the config variable `app.debug` is true.**  
 Anyway, you can temporarily turn Inspector off (just for the current request) with:
 
-	li()->turnOff();
+```php
+li()->turnOff();
+```
 
 ## <a name="messages"></a>Messages
 You can inspect objects and variables with the following methods, each of which has its own output format:
 
 |Method|Description |
 |----|-----|
-|<code>log([string  $description,] mixed $data)</code>|Outputs data with "log" format |
-|<code>info([string $description,] mixed $data)</code>|Outputs data with "info" format |
-|<code>error([string $description,] mixed $data)</code>|Outputs data with "error" format |
-|<code>warning([string $description,] mixed $data)</code>|Outputs data with "warning" format |
-|<code>success([string $description,] mixed $data)</code>|Outputs data with "success" format |
-|<code>table([string $description,] mixed $data)</code>|Outputs data inside a table |
+|`log([string  $description,] mixed $data)`|Outputs data with "log" format |
+|`info([string $description,] mixed $data)`|Outputs data with "info" format |
+|`error([string $description,] mixed $data)`|Outputs data with "error" format |
+|`warning([string $description,] mixed $data)`|Outputs data with "warning" format |
+|`success([string $description,] mixed $data)`|Outputs data with "success" format |
+|`table([string $description,] mixed $data)`|Outputs data inside a table |
 
 [comment]: $
 
 Examples:
 
 ```php	
-	li()->log("MyData", $myData);
-	li()->info($myData);
-	li()->table("clients", $myClientsCollection); 
+li()->log("MyData", $myData);
+li()->info($myData);
+li()->table("clients", $myClientsCollection); 
 ```
 Additionally, you can use the "inspect" helper function to quickly inspect objects and variables.
 
 ```php	
-	inspect($var1, $var2, $var3,...);
-
+inspect($var1, $var2, $var3,...);
 ```
 
 #### Grouping Messages
 Laravel Inspector allows you to group messages into nodes and subnodes:
 
 ```php	
-	li()->group('MyGroup');
-		li()->info($data);
-		li()->group('MySubGroup');
-			li()->error('oops', $errorCode);
-		li()->groupEnd();
-		li()->success('perfect!');
+li()->group('MyGroup');
+	li()->info($data);
+	li()->group('MySubGroup');
+		li()->error('oops', $errorCode);
 	li()->groupEnd();
+	li()->success('perfect!');
+li()->groupEnd();
 ```		
 In addition to the ability to group information, each group and subgroup excecution time will be measured and shown. If you forget to close a group, Laravel Inspector will automatically do it at the end of the script, but the excecution time for that group can not be taken.
 
@@ -171,20 +174,20 @@ In addition to the ability to group information, each group and subgroup excecut
 
 |Method|Description |
 |----|-----|
-|time(string $timerName)|Starts a timer |
-|timeEnd(string $timerName)|Ends a timer |
-|timeStamp(string $name)|Adds a single marker to the timeline |
+|`time(string $timerName)`|Starts a timer |
+|`timeEnd(string $timerName)`|Ends a timer |
+|`timeStamp(string $name)`|Adds a single marker to the timeline |
 
 [comment]: $
 
 Examples:
 
 ```php	
-	li()->timer("MyTimer");
-	// ...
-	li()->timeEnd("MyTimer");
+li()->timer("MyTimer");
+// ...
+li()->timeEnd("MyTimer");
 	
-	li()->timeStamp('Elapsed time from LARAVEL_START here'); 
+li()->timeStamp('Elapsed time from LARAVEL_START here'); 
 ```
 
 ## <a name="redirects"></a>Redirects
@@ -195,17 +198,16 @@ Laravel Inspector handles redirects smoothly; showing the collectors bag for bot
 The <code>dd()</code> method (or <code>idd()</code> helper) will dump the entire collectors bag and terminates the script: 
 
 ```php	
-	\Inspector::dd();
-	li()->dd();
+\Inspector::dd();
+li()->dd();
 	
-	// or simply
-	idd();
+// or simply
+idd();
 	
-	// adding last minute data
-	idd($var1, $var2,...)
-
-	
+// adding last minute data
+idd($var1, $var2,...)
 ```
+
 As the rest of the package, this feature intelligently determines how will be the format of the output, even if the call was performed from CLI. 
 
 Another way to make an inspection, but without interrupting the flow of the request/response, is by adding the parameter <code>laravel_inspector=dump</code> to the URL:
@@ -219,12 +221,11 @@ Thus, Laravel Inspector wont be activated until the a terminable middleware is r
 The function <code>addException()</code> will inspect our caught exceptions:  
 
 ```php	
-	try {
-		...
-	} catch (Exception $e) {
-		li()->addException($e);
-	}
-
+try {
+	...
+} catch (Exception $e) {
+	li()->addException($e);
+}
 ```
 
 Optionally, you can setup LI as the default exception renderer during development time (app.debug=true). Refer to the [configuration](#configuration) to do so. 
@@ -238,41 +239,41 @@ If you are developing, for example, an SPA and using Laravel only for the API bu
 
 ```javascript
 (function(XHR) {
-	"use strict";
+"use strict";
 
-	var send = XHR.prototype.send;
+var send = XHR.prototype.send;
 
-	XHR.prototype.send = function(data) {
-		var self = this;
-		var oldOnReadyStateChange;
-		var url = this._url;
-		this.setRequestHeader('Laravel-Inspector', 'interceptor-present');
-		function onReadyStateChange() {
-			if(self.readyState == 4 /* complete */) {
-				var response = JSON.parse(this.response);
-				if (typeof response.LARAVEL_INSPECTOR !== 'undefined') {
-					if(typeof response.LARAVEL_INSPECTOR === 'string')
-					{
-						eval(response.LARAVEL_INSPECTOR);
-					} else {
-						console.log('LARAVEL INSPECTOR ', response);
-					 }
-				 }   
-			}
-			if(oldOnReadyStateChange) {
-				oldOnReadyStateChange();
-			}
+XHR.prototype.send = function(data) {
+	var self = this;
+	var oldOnReadyStateChange;
+	var url = this._url;
+	this.setRequestHeader('Laravel-Inspector', 'interceptor-present');
+	function onReadyStateChange() {
+		if(self.readyState == 4 /* complete */) {
+			var response = JSON.parse(this.response);
+			if (typeof response.LARAVEL_INSPECTOR !== 'undefined') {
+				if(typeof response.LARAVEL_INSPECTOR === 'string')
+				{
+					eval(response.LARAVEL_INSPECTOR);
+				} else {
+					console.log('LARAVEL INSPECTOR ', response);
+				 }
+			 }   
 		}
-		if(!this.noIntercept) {            
-			if(this.addEventListener) {
-				this.addEventListener("readystatechange", onReadyStateChange, false);
-			} else {
-				oldOnReadyStateChange = this.onreadystatechange; 
-				this.onreadystatechange = onReadyStateChange;
-			}
+		if(oldOnReadyStateChange) {
+			oldOnReadyStateChange();
 		}
-		send.call(this, data);
 	}
+	if(!this.noIntercept) {            
+		if(this.addEventListener) {
+			this.addEventListener("readystatechange", onReadyStateChange, false);
+		} else {
+			oldOnReadyStateChange = this.onreadystatechange; 
+			this.onreadystatechange = onReadyStateChange;
+		}
+	}
+	send.call(this, data);
+}
 })(XMLHttpRequest);
 ```
  


### PR DESCRIPTION
This PR fixes some code highlighting in the readme to improve readability. This can also be done by adding a `lang` attribute to the `<code>` elements that were scattered around, let me know if you want me to revert it back to using the HTML tags :smile: 