### PR TITLE
Fix ErrorException: Constant LARAVEL_BOOTED already defined

### DIFF
--- a/src/InspectorServiceProvider.php
+++ b/src/InspectorServiceProvider.php
@@ -18,7 +18,9 @@ class InspectorServiceProvider extends ServiceProvider
 
         app()->booted(function(){
        
-           define('LARAVEL_BOOTED', microtime(true));
+            if(!defined('LARAVEL_BOOTED')) {
+                define('LARAVEL_BOOTED', microtime(true));
+            }
         });  
 
         // \View::composer('*', function($view)


### PR DESCRIPTION
This happens when running phpunit.