### PR TITLE
inspector removes </body> tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ In addition to the ability to group information, each group and subgroup excecut
 Examples:
 
 ```php	
-li()->timer("MyTimer");
+li()->time("MyTimer");
 // ...
 li()->timeEnd("MyTimer");
 	

--- a/src/Inspector.php
+++ b/src/Inspector.php
@@ -209,7 +209,7 @@ class inspector
                 $content = $response->getContent();
                 // Ensure string content
                 if (is_string($content)) {
-                    $content = str_replace('</body>', $inspectionBag, $response->getContent());
+                    $content = str_replace('</body>', $inspectionBag.'</body>', $response->getContent());
                     $response->setContent($content);
                 }
                 break;


### PR DESCRIPTION
inspector removes body closing tag when adding inspector content.
because of that, browsersync and any other tool is not working